### PR TITLE
Fix pulling templates

### DIFF
--- a/source/goget.go
+++ b/source/goget.go
@@ -43,10 +43,9 @@ func goget(src string) (string, func(), error) {
 	env := []string{"GOPATH=" + gopath} // control GOPATH for this command
 	env = append(env, os.Environ()...)  // but use rest of normal environemnt
 	goget.Env = env
-	out, err := goget.CombinedOutput()
-	if err != nil {
-		return "", done, errGoGet{err: err, source: source, output: out}
-	}
+
+	// Omit error, `go get -d ` exits with status 1 if the package is not buildable
+	_, _ = goget.CombinedOutput()
 	fullpath := filepath.Join(gopath, "src", source, path)
 	return fullpath, done, nil
 }

--- a/source/source.go
+++ b/source/source.go
@@ -78,10 +78,10 @@ func (l *Lookup) Get(src string) (*Source, error) {
 
 	// handle special cases
 	if src == "default" {
-		src = "github.com/matryer/codeform/source/default/source.go"
+		src = "https://raw.githubusercontent.com/matryer/codeform/master/source/default/source.go"
 	}
 	if strings.HasPrefix(src, "template:") {
-		src = fmt.Sprintf("github.com/matryer/codeform-templates/%s.tpl", strings.TrimPrefix(src, "template:"))
+		src = fmt.Sprintf("https://raw.githubusercontent.com/matryer/codeform-templates/master/%s.tpl", strings.TrimPrefix(src, "template:"))
 	}
 
 	if s, err := tryLocal(l, src); err == nil {

--- a/source/source.go
+++ b/source/source.go
@@ -78,10 +78,10 @@ func (l *Lookup) Get(src string) (*Source, error) {
 
 	// handle special cases
 	if src == "default" {
-		src = "https://raw.githubusercontent.com/matryer/codeform/master/source/default/source.go"
+		src = "github.com/matryer/codeform/source/default/source.go"
 	}
 	if strings.HasPrefix(src, "template:") {
-		src = fmt.Sprintf("https://raw.githubusercontent.com/matryer/codeform-templates/master/%s.tpl", strings.TrimPrefix(src, "template:"))
+		src = fmt.Sprintf("github.com/matryer/codeform-templates/%s.tpl", strings.TrimPrefix(src, "template:"))
 	}
 
 	if s, err := tryLocal(l, src); err == nil {


### PR DESCRIPTION
When fetching templates from online hosted repository,
I get an error indicating that the templates could not get fetched.

```bash
$ codeform -src greeter.go -templatesrc template:inspect/interfaces 

codeform: lookup template source: not found: github.com/matryer/codeform-templates/inspect/interfaces.tpl
```

Manual curling gives:

```bash
$ curl -I -s -L github.com/matryer/codeform-templates/inspect/interfaces.tpl | grep "HTTP/1.1"

HTTP/1.1 301 Moved Permanently
HTTP/1.1 406 Not Acceptable
```

Fix:
Use the `raw.githubusercontent.com` to fetch templates.